### PR TITLE
use new Docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
-README.pdf
-README.html
-shared_test_repo/
-test/integration
 .kitchen
-coverage
-Vagrantfile.erb
-
-Gemfile.lock
-Berksfile.lock
-
-ansible.cfg
 hosts
+Gemfile.lock

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -1,18 +1,28 @@
 ---
 driver:
   name: vagrant
+  driver_config:
+    http_proxy: <%= ENV['http_proxy'] || nil %>
+    https_proxy: <%= ENV['https_proxy'] || nil %>
+  vagrantfiles:
+    - kitchen_vagrant_block.rb
 
 provisioner:
   name: ansible_playbook
-  test_repo_uri: https://github.com/hardening-io/tests-ssh-hardening.git
   hosts: all
   require_ansible_repo: false
   require_ansible_omnibus: true
   require_chef_for_busser: false
   require_ruby_for_busser: false
   ansible_verbose: true
-  roles_path: ../ansible-ssh-hardening/
+  roles_path: ../ansible-nginx-hardening/
+  requirements_path: requirements.yml
   playbook: default.yml
+  http_proxy: <%= ENV['http_proxy'] || nil %>
+  https_proxy: <%= ENV['https_proxy'] || nil %>
+
+transport:
+  max_ssh_sessions: 5
 
 platforms:
 - name: ubuntu-12.04
@@ -23,6 +33,10 @@ platforms:
   driver_config:
     box: opscode-ubuntu-14.04
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+- name: ubuntu-16.04
+  driver_config:
+    box: opscode-ubuntu-16.04
+    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-16.04_chef-provisionerless.box
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4
@@ -31,6 +45,12 @@ platforms:
   driver_config:
     box: opscode-centos-6.5
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+- name: centos-6.8
+  driver_config:
+    box: bento/centos-6.8
+- name: centos-7
+  driver_config:
+    box: bento/centos-7.2
 - name: oracle-6.4
   driver_config:
     box: oracle-6.4
@@ -39,10 +59,9 @@ platforms:
   driver_config:
     box: oracle-6.5
     box_url: https://storage.us2.oraclecloud.com/v1/istoilis-istoilis/vagrant/oel65-64.box
-- name: debian-6
+- name: oracle-7
   driver_config:
-    box: debian-6
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box
+    box: boxcutter/ol72
 - name: debian-7
   driver_config:
     box: debian-7
@@ -56,10 +75,7 @@ verifier:
   name: inspec
   sudo: true
   inspec_tests:
-    - https://github.com/dev-sec/tests-ssh-hardening
+    - https://github.com/dev-sec/nginx-baseline/
 
 suites:
-- name: nginx-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: nginx-ansible_latest
+- name: nginx

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,9 @@
 driver:
   name: docker
   use_sudo: false
+  privileged: true
+  http_proxy: <%= ENV['http_proxy'] || nil %>
+  https_proxy: <%= ENV['https_proxy'] || nil %>
 
 transport:
   max_ssh_sessions: 5
@@ -10,51 +13,64 @@ provisioner:
   name: ansible_playbook
   hosts: all
   require_ansible_repo: false
-  require_ansible_omnibus: true
   require_chef_for_busser: false
   require_ruby_for_busser: false
   ansible_verbose: true
   ansible_diff: true
-  requirements_path: requirements.yml
+  hosts: all
   roles_path: ../ansible-nginx-hardening/
+  http_proxy: <%= ENV['http_proxy'] || nil %>
+  https_proxy: <%= ENV['https_proxy'] || nil %>
   playbook: default.yml
+  requirements_path: requirements.yml
 
 platforms:
-- name: ubuntu-12.04
+- name: centos6-ansible-latest
   driver:
-    image: ubuntu:12.04
-- name: ubuntu-14.04
+    image: rndmh3ro/docker-centos6-ansible:latest
+    platform: centos
+- name: centos7-ansible-latest
   driver:
-    image: ubuntu:14.04
-- name: ubuntu-16.04
+    image: rndmh3ro/docker-centos7-ansible:latest
+    platform: centos
+- name: oracle6-ansible-latest
   driver:
-    image: ubuntu:16.04
-- name: centos-6.7
+    image: rndmh3ro/docker-oracle6-ansible:latest
+    platform: centos
+- name: oracle7-ansible-latest
   driver:
-    image: centos:6.7
-- name: centos-6.8
+    image: rndmh3ro/docker-oracle7-ansible:latest
+    platform: centos
+- name: ubuntu1204-ansible-latest
   driver:
-    image: centos:6.8
-- name: centos-7
+    image: rndmh3ro/docker-ubuntu1204-ansible:latest
+    platform: ubuntu
+- name: ubuntu1404-ansible-latest
   driver:
-    image: centos:7
-    privileged: true
-    run_command: /usr/sbin/init
-- name: debian-7
+    image: rndmh3ro/docker-ubuntu1404-ansible:latest
+    platform: ubuntu
+- name: ubuntu1604-ansible-latest
   driver:
-    image: debian:7
-- name: debian-8
+    image: rndmh3ro/docker-ubuntu1604-ansible:latest
+    platform: ubuntu
+- name: debian7-ansible-latest
   driver:
-    image: debian:8
+    image: rndmh3ro/docker-debian7-ansible:latest
+    platform: debian
+- name: debian8-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian8-ansible:latest
+    platform: debian
+- name: debian9-ansible-latest
+  driver:
+    image: rndmh3ro/docker-debian9-ansible:latest
+    platform: debian
 
 verifier:
   name: inspec
   sudo: true
   inspec_tests:
-    - https://github.com/dev-sec/tests-nginx-hardening
+    - https://github.com/dev-sec/nginx-baseline
 
 suites:
-- name: nginx-ansible_1.9
-  provisioner:
-    ansible_version: 1.9.4
-- name: nginx-ansible_latest
+- name: nginx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,65 @@
 ---
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
-language: python
-python: "2.7"
+services: docker
 
 env:
-  - ANSIBLE_VERSION=latest
-  - ANSIBLE_VERSION=1.9.4
+  - distro: centos6
+    version: latest
+    init: /sbin/init
+
+  - distro: centos7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
+  - distro: oracle6
+    version: latest
+    init: /sbin/init
+
+  - distro: oracle7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    version: latest
+
+  - distro: ubuntu1604
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+
+  - distro: ubuntu1404
+    version: latest
+    init: /sbin/init
+
+#  - distro: debian7
+#    version: latest
+#    init: /sbin/init
+
+  - distro: debian8
+    version: latest
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    init: /sbin/init
+
+  - distro: debian9
+    version: latest
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
-install:
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
-  - echo -e 'localhost ansible_connection=local' > spec/inventory
-  - echo -e '[defaults]\nroles_path = ../\nhostfile = ./spec/inventory' > ansible.cfg
+  # Pull container
+  - 'docker pull rndmh3ro/docker-${distro}-ansible:${version}'
 
 script:
-  - ansible-galaxy install -r requirements.yml
-  - ansible-playbook --syntax-check spec/travis.yml
-  - ansible-playbook --sudo -v --diff spec/travis.yml
-  - ansible-playbook --sudo -v --diff spec/travis.yml --extra-vars "nginx_remove_default_site=false"
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/ansible-nginx-hardening:ro ${run_opts} rndmh3ro/docker-${distro}-ansible:${version} "${init}" > "${container_id}"'
+
+  # Install ansible galaxy requirements
+  - 'docker exec "$(cat ${container_id})" ansible-galaxy install -r /etc/ansible/roles/ansible-nginx-hardening/requirements.yml -p /etc/ansible/roles/'
+
+  # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/ansible-nginx-hardening/default.yml -vv'
+
+  # Verify role
+  - 'inspec exec https://github.com/dev-sec/nginx-baseline/ -t docker://$(cat ${container_id})'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/Gemfile
+++ b/Gemfile
@@ -2,25 +2,6 @@
 
 source 'https://rubygems.org'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2')
-  gem 'rack', '< 2.0'
-  gem 'ruby_dep', '< 1.4.0'
-  gem 'listen', '< 3.0.0'
-end
-
-group :test do
-  gem 'rake'
-  gem 'foodcritic', '~> 4.0'
-  gem 'thor-foodcritic'
-  gem 'coveralls',  require: false
-end
-
-group :development do
-  gem 'guard'
-  gem 'guard-rspec'
-  gem 'guard-kitchen'
-end
-
 group :integration do
   gem 'test-kitchen', '~> 1.0'
   gem 'kitchen-ansible'
@@ -30,10 +11,6 @@ group :integration do
   gem 'kitchen-sync'
   gem 'kitchen-transport-rsync'
   gem 'kitchen-docker'
-end
-
-group :openstack do
-  gem 'kitchen-openstack'
 end
 
 group :tools do

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,14 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook 
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+ansible_managed = Ansible managed: {file} modified on %Y-%m-%d by {uid} on {host}
+
+role_path = /vagrant
+scp_if_ssh = True

--- a/kitchen_vagrant_block.rb
+++ b/kitchen_vagrant_block.rb
@@ -1,0 +1,15 @@
+# This is a Vagrant block to allow proxy settings to be carried into Kitchen
+# You need this for all of yum/apt etc. to work!
+unless ENV['http_proxy'].empty? || Vagrant.has_plugin?("vagrant-proxyconf")
+  raise "Missing required plugin 'vagrant-proxyconf' to support HTTP(S) proxies, run `vagrant plugin install vagrant-proxyconf`"
+end
+
+Vagrant.configure(2) do |config|
+  config.proxy.http     = "#{ENV['http_proxy']}"
+  config.proxy.https    = "#{ENV['https_proxy']}"
+  config.proxy.no_proxy = "localhost,127.0.0.1"
+
+  # You may have vagrant-vbguest plugin installed to keep your images up to date
+  # - but will probably have VBoxAddition build issues with the foreign boxes listed in .kitchen.vagrant.yml
+  config.vbguest.auto_update = false
+end


### PR DESCRIPTION
This uses my own docker images (https://github.com/rndmh3ro/docker-ansible). These are just the base images with pre-installed Docker to save time and hassle when testing the roles.
This also enables full travis testing of all supported operating systems!

This too removes ansible 1.9 support, to better test the role. Also there's no more support for Ansible < 2.0, see https://groups.google.com/forum/#!topic/ansible-devel/6-6FdxZ94kc.

There are no changes in the nginx-configuration itself. Though the tests will fail. I'll fix this once this PR is merged.