### PR TITLE
Add comment filter to {{ansible_managed}} string

### DIFF
--- a/templates/hardening.conf.j2
+++ b/templates/hardening.conf.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+# {{ansible_managed|comment}}
 # Additional configuration for Nginx.
 
 client_header_buffer_size {{nginx_client_header_buffer_size}};


### PR DESCRIPTION
Multiline {{ansible_managed}} strings do not get properly commented
without the comment filter.
See http://docs.ansible.com/ansible/playbooks_filters.html#comment-filter