### PR TITLE
Fix duplicate ssl_prefer_server_ciphers error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,14 @@
   lineinfile: dest="/etc/nginx/nginx.conf" regexp="^\s*server_tokens" line="server_tokens {{nginx_server_tokens}};" insertafter="http {"
   notify: reload nginx
 
+- name: change ssl_protocols in main nginx.conf
+  lineinfile: dest="/etc/nginx/nginx.conf" regexp="^\s*ssl_protocols" line="ssl_protocols {{nginx_ssl_protocols}};" insertafter="http {"
+  notify: reload nginx
+
+- name: change ssl_prefer_server_ciphers in main nginx.conf
+  lineinfile: dest="/etc/nginx/nginx.conf" regexp="^\s*ssl_prefer_server_ciphers" line="ssl_prefer_server_ciphers {{nginx_ssl_prefer_server_ciphers}};" insertafter="http {"
+  notify: reload nginx
+
 - name: change client_max_body_size in main nginx.conf
   lineinfile: dest="/etc/nginx/nginx.conf" regexp="^\s*client_max_body_size" line="client_max_body_size {{nginx_client_max_body_size}};" insertafter="http {"
   notify: reload nginx

--- a/templates/hardening.conf.j2
+++ b/templates/hardening.conf.j2
@@ -8,10 +8,8 @@ client_header_timeout {{nginx_client_header_timeout}};
 send_timeout {{nginx_send_timeout}};
 limit_conn_zone {{nginx_limit_conn_zone}};
 limit_conn {{nginx_limit_conn}};
-ssl_protocols {{nginx_ssl_protocols}};
 ssl_ciphers {{nginx_ssl_ciphers}};
 ssl_dhparam {{nginx_dh_param}};
-ssl_prefer_server_ciphers {{nginx_ssl_prefer_server_ciphers}};
 {% for header in nginx_add_header %}
 add_header {{header}};
 {% endfor %}


### PR DESCRIPTION
Some distors (like Ubuntu 16.04) will have ssl_prefer_server_ciphers in the nginx config by default.
If this is the case nginx won't (re)start after hardening as the setting is duplicate.

Same goes for ssl_protocols, only with the difference that it throws a warning instead of an error.

> nginx: [warn] duplicate value "TLSv1.2" in /etc/nginx/conf.d/90.hardening.conf:11
> nginx: [emerg] "ssl_prefer_server_ciphers" directive is duplicate in /etc/nginx/conf.d/90.hardening.conf:14