### PR TITLE
updated minimum required ansible version to 2.5 in README, as the used 'loop' keyword was introduced in version 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It works with the following nginx-roles, including, but not limited to:
 **NOTE: This role does not work with nginx 1.0.15 or older! Please use the latest version from the official nginx repositories!**
 ## Requirements
 
-* Ansible >= 1.9
+* Ansible >= 2.5
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: 'This Ansible role provides secure nginx configurations. http://dev-sec.io/'
   company: Hardening Framework Team
   license: Apache License 2.0
-  min_ansible_version: '1.9'
+  min_ansible_version: '2.5'
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
Executing the role using the example playbook

```
- hosts: localhost
  roles:
    - dev-sec.nginx-hardening
```
with Ansible version > 2.5 (in my case 2.4.2) results to the following error:

```
[root@localhost ~]# ansible-playbook hardening.yaml
 [WARNING]: Could not match supplied host pattern, ignoring: all

 [WARNING]: provided hosts list is empty, only localhost is available

ERROR! The field 'loop' is supposed to be a string type, however the incoming data structure is a <class 'ansible.parsing.yaml.objects.AnsibleSequence'>

The error appears to have been in '/etc/ansible/roles/dev-sec.nginx-hardening/tasks/main.yml': line 66, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: remove default.conf
  ^ here
```

After some research I stumbled upon the following [solution](https://github.com/ansible/ansible/issues/38314#issuecomment-378807341) - it looks like the loop keyword is new in version 2.5, therefor not working with lower versions.

Upgrading my Ansible version to >=2.5 solved this issue for me. 